### PR TITLE
Add Angular runtime link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Table of contents:
 - macOS (Coming Soon)
 - [Android](https://help.rive.app/runtimes/overview/android)
 - [Flutter](https://help.rive.app/runtimes/overview/flutter)
+- [Angular](https://github.com/Grandgular/rive)
 - [React](https://help.rive.app/runtimes/overview/react)
 - [React-Native](https://help.rive.app/runtimes/overview/react-native)
 - [Windows](https://github.com/CommunityToolkit/Labs-Windows/blob/main/labs/RivePlayer/samples/RivePlayer.Samples/RivePlayer.md)


### PR DESCRIPTION
Added Angular support reference to the Runtime Documentation section by including a link to @grandgular/rive-angular (Grandgular/rive), making Angular integration easier to discover for Rive users.
