### PR TITLE
Add Rive Analyzer to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Table of contents:
 
 - [Rive Playground](https://nano-step.github.io/rive-playground/playground/) - Open-source visual inspector and real-time ViewModel editor for .riv files. [Source](https://github.com/nano-step/rive-playground)
 
+- [Rive Analyzer](https://nano-step.github.io/rive-analyzer/) - Open-source, fully client-side tool that grades a `.riv` against a best-practice catalog: full inventory, an A–F score with per-finding reasons, and an optimization plan — with every rule linked to the official Rive docs. From the author of Rive Playground. [Source](https://github.com/nano-step/rive-analyzer)
+
 - [Rive Animation Viewer](https://forge.mograph.life/apps/rav/) - Open-source local and desktop viewer for `.riv` files with runtime controls, ViewModelInstance debugging, JavaScript configuration editing, standalone export, and MCP remote control. [Source](https://github.com/ivg-design/rive-animation-viewer)
 
 ---


### PR DESCRIPTION
Adds **Rive Analyzer** to the **Resources** section.

**[Rive Analyzer](https://nano-step.github.io/rive-analyzer/)** — a free, fully client-side web app: drop a `.riv` and get a complete inventory (artboards, state machines, inputs, view-models) plus a scored **A–F best-practice + optimization report**. Each finding shows *why* points were lost and *how* to improve, and **every rule links to the official Rive documentation**. Nothing is uploaded — analysis runs entirely in the browser via `@rive-app/canvas-advanced`.

- Live: https://nano-step.github.io/rive-analyzer/
- Source (MIT): https://github.com/nano-step/rive-analyzer

For context, I'm also the author of **Rive Playground** (already listed in Resources) — Rive Analyzer is a companion tool focused on best-practice grading, so I placed it right alongside.

Single-line addition following the existing Resources entry format; no other changes.